### PR TITLE
datadog: sample_rate omitted by default

### DIFF
--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -87,11 +87,6 @@ const (
 	// Parameters for a shared memory zone that will keep states for various keys.
 	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
 	defaultLimitConnZoneVariable = "$binary_remote_addr"
-
-	// Default sentinel value for Configuration.DatadogSampleRate, indicating
-	// that the Datadog tracer should consult the Datadog Agent for sampling
-	// rates rather than use a configured value.
-	DatadogDynamicSampleRate = -1.0
 )
 
 // Configuration represents the content of nginx.conf file
@@ -713,7 +708,7 @@ type Configuration struct {
 
 	// DatadogSampleRate specifies sample rate for any traces created.
 	// Default: use a dynamic rate instead
-	DatadogSampleRate float32 `json:"datadog-sample-rate"`
+	DatadogSampleRate *float32 `json:"datadog-sample-rate",omitempty`
 
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
 	MainSnippet string `json:"main-snippet"`
@@ -999,7 +994,7 @@ func NewDefault() Configuration {
 		DatadogEnvironment:                     "prod",
 		DatadogCollectorPort:                   8126,
 		DatadogOperationNameOverride:           "nginx.handle",
-		DatadogSampleRate:                      DatadogDynamicSampleRate,
+		DatadogSampleRate:                      nil,
 		LimitReqStatusCode:                     503,
 		LimitConnStatusCode:                    503,
 		SyslogPort:                             514,

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -87,6 +87,11 @@ const (
 	// Parameters for a shared memory zone that will keep states for various keys.
 	// http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone
 	defaultLimitConnZoneVariable = "$binary_remote_addr"
+
+	// Default sentinel value for Configuration.DatadogSampleRate, indicating
+	// that the Datadog tracer should consult the Datadog Agent for sampling
+	// rates rather than use a configured value.
+	DatadogDynamicSampleRate = -1.0
 )
 
 // Configuration represents the content of nginx.conf file
@@ -706,15 +711,8 @@ type Configuration struct {
 	// Default: nginx.handle
 	DatadogOperationNameOverride string `json:"datadog-operation-name-override"`
 
-	// DatadogPrioritySampling specifies to use client-side sampling
-	// If true disables client-side sampling (thus ignoring sample_rate) and enables distributed
-	// priority sampling, where traces are sampled based on a combination of user-assigned
-	// Default: true
-	DatadogPrioritySampling bool `json:"datadog-priority-sampling"`
-
 	// DatadogSampleRate specifies sample rate for any traces created.
-	// This is effective only when datadog-priority-sampling is false
-	// Default: 1.0
+	// Default: use a dynamic rate instead
 	DatadogSampleRate float32 `json:"datadog-sample-rate"`
 
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
@@ -1001,8 +999,7 @@ func NewDefault() Configuration {
 		DatadogEnvironment:                     "prod",
 		DatadogCollectorPort:                   8126,
 		DatadogOperationNameOverride:           "nginx.handle",
-		DatadogSampleRate:                      1.0,
-		DatadogPrioritySampling:                true,
+		DatadogSampleRate:                      DatadogDynamicSampleRate,
 		LimitReqStatusCode:                     503,
 		LimitConnStatusCode:                    503,
 		SyslogPort:                             514,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1083,12 +1083,11 @@ func datadogOpentracingCfg(cfg ngx_config.Configuration) (string, error) {
 		"operation_name_override": cfg.DatadogOperationNameOverride,
 	}
 
-	// Omit "sample_rate" if the configuration's sample rate is set to the
-	// default sentinel value DatadogDynamicSampleRate (-1).
+	// Omit "sample_rate" if the configuration's sample rate is unset (nil).
 	// Omitting "sample_rate" from the plugin JSON indicates to the tracer that
 	// it should use dynamic rates instead of a configured rate.
-	if cfg.DatadogSampleRate != ngx_config.DatadogDynamicSampleRate {
-		jsn["sample_rate"] = cfg.DatadogSampleRate
+	if cfg.DatadogSampleRate != nil {
+		jsn["sample_rate"] = *cfg.DatadogSampleRate
 	}
 
 	jsnBytes, err := json.Marshal(jsn)


### PR DESCRIPTION
Here's what I plan to propose in a PR upstream.

~It uses the magic float `-1.0` for `sample_rate` to mean "use priority sampling instead," and then changes the default value to be `-1.0`.~

It represents `DatadogSampleRate` as a `*float32` instead of `float32`. This way, the default value of `nil` can be interpreted to mean "no rate specified." The configuration is decoded by the `mapstructure` package, which supports this style.

In order to conditionally include `"sample_rate": ...` in `/etc/nginx/opentracing.json`, I had to generalize the code that produces that file. I put the template-based implementation in a dedicated function, and that function is called for all tracers except Datadog. Datadog has its own function that uses the `encoding/json` package instead of `text/template`. 